### PR TITLE
Remove suffixes to use content negotiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,5 +54,5 @@ p.92 21行目: Socket.ip_address_list
 Debian GNU/Linux はいつのころからか /etc/hosts で、
 localhost は 127.0.0.1, ユーザが決めたホスト名は 127.0.1.1 を返すように設定されるようになりました。
 このことについては Debian のマニュアルの
-https://www.debian.org/doc/manuals/debian-reference/ch05.en.html#_the_hostname_resolution
+https://www.debian.org/doc/manuals/debian-reference/ch05#_the_hostname_resolution
 に書いてあります。


### PR DESCRIPTION
https://www.debian.org/intro/cn に書いてあるように content negotiation でブラウザーの設定に応じて日本語などが出るように拡張子を取り除いた方が良いのではないでしょうか。
